### PR TITLE
chore: preprocess the path before sending to wezterm

### DIFF
--- a/lua/wezterm.lua
+++ b/lua/wezterm.lua
@@ -1,3 +1,4 @@
+local Path = require("plenary.path")
 local fmt = string.format
 
 local wezterm = {
@@ -164,7 +165,8 @@ function wezterm.spawn(program, opts)
   end
   if opts.cwd then
     args:insert("--cwd")
-    args:insert(opts.cwd)
+    local path = Path:new(opts.cwd)
+    args:insert(path:expand())
   end
   if program then
     args:insert(program)


### PR DESCRIPTION
Hi guys,
I had the following problem, i dont know why, but on my mac the command to spawn a program could not handle `cwd` with `~/.config/nvim`. So I implemented a solution with plenary, is it ok to add a dependency for you guys ?